### PR TITLE
fix install --HEAD failed

### DIFF
--- a/ghq.rb
+++ b/ghq.rb
@@ -23,8 +23,11 @@ class Ghq < Formula
       ln_s buildpath, gopath/'src/github.com/motemen/ghq'
 
       system 'make', 'VERSION=HEAD (homebrew)'
+      tempnam = buildpath.to_str.match(%r{ghq-(.+)$})[1]
+      bin.install "ghq-#{tempnam}" => 'ghq'
+    else
+      bin.install 'ghq'
     end
 
-    bin.install 'ghq'
   end
 end


### PR DESCRIPTION
MBA 10.9.3

```
% brew --version
0.9.5

% brew install -v motemen/ghq/ghq --HEAD
git clone https://github.com/motemen/homebrew-ghq /usr/local/Library/Taps/motemen/homebrew-ghq
Cloning into '/usr/local/Library/Taps/motemen/homebrew-ghq'...
remote: Counting objects: 21, done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 21 (delta 7), reused 19 (delta 5)
Unpacking objects: 100% (21/21), done.
Checking connectivity... done.
Tapped 1 formula
==> Cloning https://github.com/motemen/ghq
git --git-dir /Library/Caches/Homebrew/ghq--git/.git status -s
Updating /Library/Caches/Homebrew/ghq--git
git config remote.origin.url https://github.com/motemen/ghq
git config remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
git fetch origin
git checkout -f master
Already on 'master'
Your branch is up-to-date with 'origin/master'.
git reset --hard origin/master
HEAD is now at b0059c6 motemen/github-create-release is no longer required
==> Checking out branch master
git checkout-index -a -f --prefix=/private/tmp/ghq-zMcX/
==> make VERSION=HEAD (homebrew)
go get -d
go build  -ldflags " -X main.Version \"HEAD (homebrew)\" -X github.com/motemen/ghq/pocket.ConsumerKey \"$POCKET_CONSUMER_KEY\" "
Error: ghq does not exist
```
