### PR TITLE
Remove dependency on unzip formula

### DIFF
--- a/ghq.rb
+++ b/ghq.rb
@@ -12,8 +12,6 @@ class Ghq < Formula
   if build.head?
     depends_on 'go' => :build
     depends_on 'hg' => :build
-  else
-    depends_on 'unzip' => :build
   end
 
   def install


### PR DESCRIPTION
### 主旨

unzipへの依存の宣言を外しても問題無くインストール出来そうなので、外してはどうでしょう。
### 背景

下のインストール方法で失敗するので調べたところ、unzipはOSXに最初から入っていること、unzipという名前のformulaは公式のレポジトリには含まれておらず、[homebrew/dupes](https://github.com/Homebrew/homebrew-dupes)に含まれていることを知りました。

``` sh
$ brew tap motemen/ghq
$ brew install ghq
Error: No available formula for unzip (dependency of ghq)
Searching taps...
homebrew/dupes/unzip
```
