### PR TITLE
Support Linux x86_64

### DIFF
--- a/ghq.rb
+++ b/ghq.rb
@@ -3,8 +3,13 @@ require 'formula'
 HOMEBREW_GHQ_VERSION='0.6'
 class Ghq < Formula
   homepage 'https://github.com/motemen/ghq'
-  url "https://github.com/motemen/ghq/releases/download/v#{HOMEBREW_GHQ_VERSION}/ghq_darwin_amd64.zip"
-  sha1 'eff77abc345fa2c5581875f4e3c8fc4e2b9bf0ac'
+  if OS.mac?
+    url "https://github.com/motemen/ghq/releases/download/v#{HOMEBREW_GHQ_VERSION}/ghq_darwin_amd64.zip"
+    sha1 'eff77abc345fa2c5581875f4e3c8fc4e2b9bf0ac'
+  elsif OS.linux?
+    url "https://github.com/motemen/ghq/releases/download/v#{HOMEBREW_GHQ_VERSION}/ghq_linux_amd64.tar.gz"
+    sha1 "b6c45ff1a57b1fac12b2f49ae12b9dbf2c71a936"
+  end
 
   version HOMEBREW_GHQ_VERSION
   head 'https://github.com/motemen/ghq', :using => :git, :branch => 'master'


### PR DESCRIPTION
I checked to install following environment.
Ubuntu 14.04 x86_64
linuxbrew 0.9.5

```shell
[develop ~]$ brew install sona-tar/ghq/ghq                                                  
==> Tapping sona-tar/ghq
Cloning into '/home/develop/.linuxbrew/Library/Taps/sona-tar/homebrew-ghq'...
remote: Counting objects: 6, done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 6 (delta 0), reused 4 (delta 0), pack-reused 0
Unpacking objects: 100% (6/6), done.
Checking connectivity... done.
Tapped 1 formula (31 files, 224K)
==> Installing ghq from sona-tar/homebrew-ghq
==> Downloading https://github.com/motemen/ghq/releases/download/v0.6/ghq_linux_amd64.tar.gz
######################################################################## 100.0%
==> Caveats
zsh completion has been installed to:
  /home/develop/.linuxbrew/share/zsh/site-functions

==> Summary
/home/develop/.linuxbrew/Cellar/ghq/0.6: 4 files, 3.9M, built in 4 seconds
[develop ~]$ which ghq                                                                      
/home/develop/.linuxbrew/bin/ghq
```