### PR TITLE
Update checksum algorithm because sha1 has been disabled

### DIFF
--- a/ghq.rb
+++ b/ghq.rb
@@ -5,10 +5,10 @@ class Ghq < Formula
   homepage 'https://github.com/motemen/ghq'
   if OS.mac?
     url "https://github.com/motemen/ghq/releases/download/v#{HOMEBREW_GHQ_VERSION}/ghq_darwin_amd64.zip"
-    sha1 'a860532b6529be74604334e5086c139831fc2be9'
+    sha256 '96c6b8dc16fda605cad0b2000c1856cfc9df5bfe1987ba38e86cd773f39fb3e7'
   elsif OS.linux?
     url "https://github.com/motemen/ghq/releases/download/v#{HOMEBREW_GHQ_VERSION}/ghq_linux_amd64.zip"
-    sha1 "d939d68338659dc0721056c62a5b8f709554b5ce"
+    sha256 'd0d285d190ab5adb06c120a005305b41e8e47ef068de85f8e4de2fac4cd8cf17'
   end
 
   version HOMEBREW_GHQ_VERSION


### PR DESCRIPTION
Hi, there

I tried `brew update` in my machine, but this formula show an error.
It seems to checksum algorithm 
Here are logs to execute `brew tap motemen/homebrew-ghq`.

```
$ brew tap motemen/homebrew-ghq
==> Tapping motemen/ghq
Cloning into '/usr/local/Library/Taps/motemen/homebrew-ghq'...
remote: Counting objects: 6, done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 6 (delta 0), reused 4 (delta 0), pack-reused 0
Unpacking objects: 100% (6/6), done.
Checking connectivity... done.
Error: Invalid formula: /usr/local/Library/Taps/motemen/homebrew-ghq/ghq.rb
Calling Formula.sha1 is disabled!
Use Formula.sha256 instead.
/usr/local/Library/Taps/motemen/homebrew-ghq/ghq.rb:8:in `<class:Ghq>'
Please report this to the motemen/ghq tap!
Error: Cannot tap motemen/ghq: invalid syntax in tap!
```

So I fetch sha256 checksum and update it.
I confirmed to run successfully `brew tap aibou/homebrew-ghq`.
Please confirm it.